### PR TITLE
Add a note about the syntax of the MATRIX_ROOMS field; it took me some time

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -1,6 +1,9 @@
 APP_PORT=3000
 APP_ALERTMANAGER_SECRET=<secret key for the webhook events>
 MATRIX_HOMESERVER_URL=https://homeserver.tld
+# The rooms to send alerts to, separated by a |
+# Each entry contains the receiver name (from alertmanager) and the
+# internal id (not the public alias) of the Matrix channel to forward to.
 MATRIX_ROOMS=receiver1/!abcdefgh:homeserver.tld|receiver2/!qwerty:homeserver.tld
 MATRIX_TOKEN=<token from the alertmanager user on matrix>
 MATRIX_USER=@alertmanager:homeserver.tld


### PR DESCRIPTION
Add a note about the syntax of the MATRIX_ROOMS field; it took me some time
to work out this did not support public aliases.
