### PR TITLE
Basic auth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ receivers:
 
 The secret key obviously should match the one in the alertmanager configuration.
 
+Alternatively, put the secret in a separate file and use basic auth with username `prometheus`:
+
+```yaml
+receivers:
+- name: 'myreceiver'
+  webhook_configs:
+  - url: 'https://my-matrix-alertmanager.tld/alerts
+    http_config:
+      basic_auth:
+        username: prometheus
+        password_file: /path/to/password.secret
+```
+
 ### Prometheus rules
 
 Add some styling to your prometheus rules

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Alternatively, put the secret in a separate file and use basic auth with usernam
 receivers:
 - name: 'myreceiver'
   webhook_configs:
-  - url: 'https://my-matrix-alertmanager.tld/alerts
+  - url: 'https://my-matrix-alertmanager.tld/alerts'
     http_config:
       basic_auth:
         username: alertmanager

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ receivers:
 
 The secret key obviously should match the one in the alertmanager configuration.
 
-Alternatively, put the secret in a separate file and use basic auth with username `prometheus`:
+Alternatively, put the secret in a separate file and use basic auth with username `alertmanager`:
 
 ```yaml
 receivers:
@@ -51,7 +51,7 @@ receivers:
   - url: 'https://my-matrix-alertmanager.tld/alerts
     http_config:
       basic_auth:
-        username: prometheus
+        username: alertmanager
         password_file: /path/to/password.secret
 ```
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -6,7 +6,7 @@ const routes = {
         res.send('Hey 👋')
     },
     postAlerts: async (req, res) => {
-        const secret = req.query.secret
+        const secret = req.query.secret || utils.getBasicAuthPassword(req)
         if (secret !== process.env.APP_ALERTMANAGER_SECRET) {
             res.status(403).end()
             return

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,10 @@
 const utils = {
 
+    getBasicAuthPassword: req => {
+        const content = req.get("Authorization").replace(/^Bearer /, '')
+        return atob(content).replace(/^prometheus:/, '')
+    }
+
     getRoomForReceiver: receiver => {
         /*
         Get the right roomId for the given receiver from MATRIX_ROOMS configuration item.

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,7 +3,7 @@ const utils = {
     getBasicAuthPassword: req => {
         const content = req.get("Authorization").replace(/^Basic /, '')
         return atob(content).replace(/^alertmanager:/, '')
-    }
+    },
 
     getRoomForReceiver: receiver => {
         /*

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,7 +2,7 @@ const utils = {
 
     getBasicAuthPassword: req => {
         const content = req.get("Authorization").replace(/^Bearer /, '')
-        return atob(content).replace(/^prometheus:/, '')
+        return atob(content).replace(/^alertmanager:/, '')
     }
 
     getRoomForReceiver: receiver => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,7 @@
 const utils = {
 
     getBasicAuthPassword: req => {
-        const content = req.get("Authorization").replace(/^Bearer /, '')
+        const content = req.get("Authorization").replace(/^Basic /, '')
         return atob(content).replace(/^alertmanager:/, '')
     }
 


### PR DESCRIPTION
I don't want to have to put my password in the URL as a post parameter. Using basic auth leverages existing `webhook_configs[].http_config.basic_auth.password_file` option to read the password from a file instead (allowing me to check my alertmanager config into git!)

Username must be `alertmanager`. Password is the same as the `APP_ALERTMANAGER_SECRET` environment variable.

So far untested, just wanted to get the PR in.