### PR TITLE
Richer alerts; improved docs; easier testing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
+.env
+.git
+.idea
 node_modules
 npm-debug.log
-.env
-.idea
-.git
-tests

--- a/.env.default
+++ b/.env.default
@@ -1,5 +1,9 @@
 APP_PORT=3000
 APP_ALERTMANAGER_SECRET=<secret key for the webhook events>
+
+# DEBUG | VERBOSE | INFO | WARNING | ERROR
+LOG_LEVEL=VERBOSE
+
 MATRIX_HOMESERVER_URL=https://homeserver.tld
 # The rooms to send alerts to, separated by a |
 # Each entry contains the receiver name (from alertmanager) and the

--- a/.env.default
+++ b/.env.default
@@ -1,6 +1,11 @@
 APP_PORT=3000
 APP_ALERTMANAGER_SECRET=<secret key for the webhook events>
 
+# Optional URLs used for alerts with links back to your alertman instance and dashboards
+APP_ALERTMANAGER_URL=https://alertman.domain/#/alerts
+APP_ALERTMANAGER_DEFAULT_DASHBOARD_URL=https://grafana.domain/dashboard/path?orgId=2&var-job=nodes&var-node=All&var-hostname=
+APP_ALERTMANAGER_DEFAULT_DASHBOARD_URL_APPEND_HOSTNAME=true
+
 # DEBUG | VERBOSE | INFO | WARNING | ERROR
 LOG_LEVEL=VERBOSE
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY package*.json ./
 
 RUN npm install --only=production
 
-COPY . .
+COPY src /app/src
 
 EXPOSE 3000
 

--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,6 @@ test:
 		--userns host \
 		node:18-alpine \
 		sh -c "npm install && npm run test"
+
+build:
+	docker build -t matrix-alertmanager .

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ test:
 	docker run -it --rm \
 		--workdir /app \
 		-v $(PWD):/app \
+		-e LOG_LEVEL=INFO \
 		--userns host \
 		node:18-alpine \
 		sh -c "npm install && npm run test"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+test:
+	docker run -it --rm \
+		--workdir /app \
+		-v $(PWD):/app \
+		--userns host \
+		node:18-alpine \
+		sh -c "npm install && npm run test"

--- a/README.md
+++ b/README.md
@@ -19,15 +19,21 @@ Main features:
 
 ### Configuration
 
-Whether running manually or via the Docker image, the configuration is set 
+Whether running manually or via the Docker image, the configuration is set
 via environment variables. When running manually, copy `.env.default`
-into `.env`, set the values and they will be loaded automatically. 
-When using the Docker image, set the environment variables when running 
+into `.env`, set the values and they will be loaded automatically.
+When using the Docker image, set the environment variables when running
 the container.
 
 ### Docker
 
 The [Docker image](https://cloud.docker.com/repository/docker/jaywink/matrix-alertmanager) `jaywink/matrix-alertmanager:latest` is the easiest way to get the service running. Ensure you set the required environment variables listed in `.env.default` in this repository.
+
+#### Building locally
+
+You can build the container locally:
+
+    make build
 
 ### Alertmanager
 
@@ -35,7 +41,7 @@ You will need to configure a webhook receiver in Alertmanager. It should looks s
 
 ```yaml
 receivers:
-- name: 'myreceiver'
+- name: 'receiver1'
   webhook_configs:
   - url: 'https://my-matrix-alertmanager.tld/alerts?secret=veryverysecretkeyhere'
 ```
@@ -46,7 +52,7 @@ Alternatively, put the secret in a separate file and use basic auth with usernam
 
 ```yaml
 receivers:
-- name: 'myreceiver'
+- name: 'receiver2'
   webhook_configs:
   - url: 'https://my-matrix-alertmanager.tld/alerts'
     http_config:
@@ -54,6 +60,15 @@ receivers:
         username: alertmanager
         password_file: /path/to/password.secret
 ```
+
+Note that the receiver `name` must match a configured recevier in the
+`MATRIX_ROOMS` env variable.
+
+Optional convenience links can be configured back to your alertmanager
+instance and/or a default dashboard.
+
+If an alert is received with a `url` in the `annotations` that URL will be used
+rather than the default dashboard URL.
 
 ### Prometheus rules
 
@@ -64,6 +79,7 @@ rules:
 - alert: High Memory Usage of Container
   annotations:
     description: Container named <strong>{{\$labels.container_name}}</strong> in <strong>{{\$labels.pod_name}}</strong> in <strong>{{\$labels.namespace}}</strong> is using more than 75% of Memory Limit
+    url: https://grafana.domain/path/do/dashboard?orgId=12&var-host={\$labels.container_name}
   expr: |
     ((( sum(container_memory_usage_bytes{image!=\"\",container_name!=\"POD\", namespace!=\"kube-system\"}) by (namespace,container_name,pod_name, instance)  / sum(container_spec_memory_limit_bytes{image!=\"\",container_name!=\"POD\",namespace!=\"kube-system\"}) by (namespace,container_name,pod_name, instance) ) * 100 ) < +Inf ) > 75
   for: 5m
@@ -72,6 +88,16 @@ rules:
 ```
 
 NOTE! Currently, the bot cannot talk HTTPS, so you need to have a reverse proxy in place to terminate SSL, or use unsecure unencrypted connections.
+
+## Testing
+
+The tests can either be run locally with:
+
+    npm test
+
+..or from within a docker container:
+
+    make test
 
 ## TODO
 

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,7 @@
 const express = require('express')
 const client = require('./client')
 const routes = require('./routes')
+const log = require('./log')
 
 // Config
 require('dotenv').config()
@@ -13,14 +14,11 @@ app.get('/', routes.getRoot)
 app.post('/alerts', routes.postAlerts)
 // Initialize Matrix client
 client.init().then(() => {
-    // eslint-disable-next-line no-console
-    console.log('matrix-alertmanager initialized and ready')
+    log.info('matrix-alertmanager initialized and ready')
     app.listen(process.env.APP_PORT, () => {})
 }).catch(e => {
-    // eslint-disable-next-line no-console
-    console.error('initialization failed')
-    // eslint-disable-next-line no-console
-    console.error(e)
+    log.error('initialization failed')
+    log.error(e)
 })
 
 module.exports = app

--- a/src/client.js
+++ b/src/client.js
@@ -1,5 +1,6 @@
 const matrix = require('matrix-js-sdk')
 const striptags = require('striptags')
+const log = require('./log')
 
 let joinedRoomsCache = []
 
@@ -12,7 +13,7 @@ const client = {
                     joinedRoomsCache.push(room.roomId)
                 }
             } catch (ex) {
-                console.warn(`Could not join room ${roomId} - ${ex}`)
+                log.warn(`Could not join room ${roomId} - ${ex}`)
             }
         }
     },

--- a/src/log.js
+++ b/src/log.js
@@ -1,0 +1,30 @@
+// DEBUG | VERBOSE | INFO | WARNING | ERROR
+const logLevel = process.env.LOG_LEVEL || 'INFO'
+
+const log = {
+    error: message => {
+        console.error(message)
+    },
+    warn: message => {
+        if ( ['DEBUG', 'VERBOSE', 'INFO', 'WARNING'].indexOf(logLevel) > -1 ) {
+            console.warning(message)
+        }
+    },
+    info: message => {
+        if ( ['DEBUG', 'VERBOSE', 'INFO'].indexOf(logLevel) > -1 ) {
+            console.info(message)
+        }
+    },
+    verbose: message => {
+        if ( ['DEBUG', 'VERBOSE'].indexOf(logLevel) > -1 ) {
+            console.log(message)
+        }
+    },
+    debug: message => {
+        if ( ['DEBUG'].indexOf(logLevel) > -1 ) {
+            console.debug(message)
+        }
+    }
+}
+
+module.exports = log

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,5 +1,6 @@
 const client = require('./client')
 const utils = require('./utils')
+const log = require('./log')
 
 const routes = {
     getRoot: (req, res) => {
@@ -11,16 +12,23 @@ const routes = {
             res.status(403).end()
             return
         }
+        if ( process.env.LOG_LEVEL === 'DEBUG' ) {
+            log.verbose(JSON.stringify(req.body))
+        }
         const alerts = utils.parseAlerts(req.body)
 
         if (!alerts) {
-            res.json({'result': 'no alerts found in payload'})
+            const msg = 'no alerts found in payload'
+            log.info(msg)
+            res.json({'result': msg})
             return
         }
 
         const roomId = utils.getRoomForReceiver(req.body.receiver)
         if (!roomId) {
-            res.json({'result': 'no rooms configured for this receiver'})
+            const msg = 'no rooms configured for this receiver'
+            log.info(msg)
+            res.json({'result': msg})
             return
         }
 
@@ -29,10 +37,9 @@ const routes = {
             await Promise.all(promises)
             res.json({'result': 'ok'})
         } catch (e) {
-            // eslint-disable-next-line no-console
-            console.error(e)
+            log.error(e)
             res.status(500)
-            res.json({'result': 'error'})
+            res.json({'result': 'error sending alert'})
         }
     },
 }


### PR DESCRIPTION
You may not want to merge this, but thought I'd share just in case.

From the individual commit message:

- Alerts now:
  - link to the alertmanager URL and a dashboard if env vars are
    configured.
  - all labels other than explicitly formatted labels are included in the
    alert output
  - when annotation.url is set the link will be included in the alert
  - fixed extra spaces that broke the alert link
  - emit the alert severity instead of "firing" when available
- New logging module with configurable log level.
- Cleaner contianer