### PR TITLE
Improve usage with Prometheus-Operator

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -30,7 +30,7 @@ const client = {
         const joinedRooms = rooms.joined_rooms
         const roomConfigs = process.env.MATRIX_ROOMS.split('|')
         roomConfigs.forEach(async roomConfig => {
-            const room = roomConfig.split('/')
+            const room = roomConfig.split(';')
             if (joinedRooms.indexOf(room[1]) === -1) {
                 await this.ensureInRoom(room[1])
             }

--- a/src/utils.js
+++ b/src/utils.js
@@ -14,7 +14,7 @@ const utils = {
         const roomConfigs = process.env.MATRIX_ROOMS.split('|')
         let roomId = false
         for (let config of roomConfigs) {
-            const roomConfig = config.split('/')
+            const roomConfig = config.split(';')
             if (roomConfig[0] === receiver) {
                 roomId = roomConfig[1]
                 break


### PR DESCRIPTION
Prometheus-Operator prepends the following the all receiver names: `<namespace>/<alertmanager-instance-name>/`

Since `MATRIX_ROOMS` currently uses `/` as a separator for `<RECEIVER>/<MATRIX_ROOM_ID>` _matrix-alertmanager_ can currently not be used with Prometheus-Operator.

I suggest replacing '/' with ';' in MATRIX_ROOMS env var.