### PR TITLE
Fix DoS when a request is made without auth header

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -6,7 +6,10 @@ const routes = {
         res.send('Hey 👋')
     },
     postAlerts: async (req, res) => {
-        const secret = req.query.secret || utils.getBasicAuthPassword(req)
+        let secret = req.query.secret
+        if (!secret && req.get("Authorization")) {
+            secret = utils.getBasicAuthPassword(req)
+        }
         if (secret !== process.env.APP_ALERTMANAGER_SECRET) {
             res.status(403).end()
             return


### PR DESCRIPTION
This fixes a Denial of Service attack when someone hits the `/alerts` endpoint with no auth. To reproduce this:
```
curl -X POST 127.0.0.1:4001/alerts
```
and the output from the service:
```
matrix-alertmanager initialized and ready
/app/src/utils.js:4
        const content = req.get("Authorization").replace(/^Basic /, '')
                                                ^

TypeError: Cannot read properties of undefined (reading 'replace')
    at Object.getBasicAuthPassword (/app/src/utils.js:4:49)
    at postAlerts (/app/src/routes.js:9:50)
    at Layer.handle [as handle_request] (/app/node_modules/express/lib/router/layer.js:95:5)
    at next (/app/node_modules/express/lib/router/route.js:149:13)
    at Route.dispatch (/app/node_modules/express/lib/router/route.js:119:3)
    at Layer.handle [as handle_request] (/app/node_modules/express/lib/router/layer.js:95:5)
    at /app/node_modules/express/lib/router/index.js:284:15
    at Function.process_params (/app/node_modules/express/lib/router/index.js:346:12)
    at next (/app/node_modules/express/lib/router/index.js:280:10)
    at jsonParser (/app/node_modules/body-parser/lib/types/json.js:113:7)

Node.js v20.19.1
```