### PR TITLE
Add support for custom links

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -12,3 +12,13 @@ MATRIX_USER=@alertmanager:homeserver.tld
 # Set this to 1 to make firing alerts do a `@room` mention.
 # NOTE! Bot should also have enough power in the room for this to be useful.
 MENTION_ROOM=0
+# Custom alert links in format "name1:url_template1|name2:url_template2"
+# URL templates can include placeholders:
+# - {generatorURL}: The original alert URL
+# - {labels.xxx}: Any label from the alert (e.g., {labels.instance}, {labels.alertname})
+# - {annotations.xxx}: Any annotation from the alert (e.g., {annotations.summary})
+# If a url entry is a singular annotation and the annotation exists in data
+# received from AlertManager then it will be used as the url. If the annotation
+# doesn't exist then this particular name is skipped completely.
+# Example: ALERT_LINKS=Grafana:{annotations.grafana}|Silence:https://alertmanager.example.com/#/silences/new?filter={labels.alertname}|Multiple words or emojis📈:{generatorURL}
+# ALERT_LINKS=

--- a/src/utils.js
+++ b/src/utils.js
@@ -71,6 +71,9 @@ const utils = {
         if (data.annotations.description !== undefined) {
             parts.push('<br>', data.annotations.description)
         }
+        if (data.annotations.summary !== undefined && data.annotations.description === undefined) {
+            parts.push('<br>', data.annotations.summary)
+        }
         // Add custom links if configured
         if (process.env.ALERT_LINKS) {
             const linkConfigs = process.env.ALERT_LINKS.split('|')


### PR DESCRIPTION
This patchset:
1) Prints `annotations.summary` if `annotations.description` doesn't exist. I've seen quite a few alerts out there that only have a summary.
2) Adds support for a new env variable that allows the user to specify multiple urls to add to the posted message. This isn't a fully templating feature as requested in #35, but I believe it covers most needs and cases I've run into over the years.

As an example to help with reviewing this PR, when configured like this:
```
ALERT_LINKS=📉 Grafana:{annotations.grafana}|Silence:https://alertmanager.example.com/#/silences/new?filter={annotations.description}&datacenter={labels.dc}|Original source:{generatorURL}|Won't be show:{annotations.example}|Will be shown:{annotations.url}
```

and this message from AlertManager:
```
 {
 "receiver": "matrix",
 "status": "firing",
 "alerts": [
    {
      "status": "firing",
      "labels": {
        "alertnames": "Test",
        "dc": "eu-west-1",
        "instance": "localhost:9090",
        "job": "prometheus24"
      },
      "annotations": {
        "summary": "A short summary",
        "grafana": "https://grafana.erethon.com/mple/test/123",
        "url": "https://example.com",
        "description": "A long description "
      },
      "startsAt": "2018-08-03T09:52:26.739266876+02:00",
      "endsAt": "0001-01-01T00:00:00Z",
      "generatorURL": "http://example.com:9090/graph?g0.expr=go_memstats_alloc_bytes+%3E+0\u0026g0.tab=1"                                
    }
  ]}
 ```
 This will post:
 
![ma_000](https://github.com/user-attachments/assets/25724df2-c4d3-460f-bcd3-8d8ee535a335)

with a `formatted_body` in matrix of:
```
"formatted_body": "@room <br> <strong><font color=\"#dc3545\">FIRING:</font></strong> localhost:9090 <br> A long description <br><a href=\" https://grafana.erethon.com/mple/test/123 \"> 📉 Grafana </a> <br><a href=\" https://alertmanager.example.com/#/silences/new?filter=A long description&foobar=eu-west-1 \"> Silence </a> <br><a href=\" http://example.com:9090/graph?g0.expr=go_memstats_alloc_bytes+%3E+0&g0.tab=1 \"> Original source </a> <br><a href=\" https://example.com \"> Will be shown </a>"
```

Note, that the entry with name `Won't be shown` isn't in the message because an `annotations.example` doesn't exist.

Let me know if something isn't clear and sorry if the code isn't really clear, I'm not proficient in JS beyond quick hacks.