### PR TITLE
Return 500 in case of no alerts in payload or no corresponding rooms

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -17,14 +17,14 @@ const routes = {
         const alerts = utils.parseAlerts(req.body)
 
         if (!alerts) {
-            res.status(500)
+            res.status(400)
             res.json({'result': 'no alerts found in payload'})            
             return
         }
 
         const roomId = utils.getRoomForReceiver(req.body.receiver)
         if (!roomId) {
-            res.status(500)
+            res.status(400)
             res.json({'result': 'no rooms configured for this receiver'})            
             return
         }

--- a/src/routes.js
+++ b/src/routes.js
@@ -17,13 +17,15 @@ const routes = {
         const alerts = utils.parseAlerts(req.body)
 
         if (!alerts) {
-            res.json({'result': 'no alerts found in payload'})
+            res.status(500)
+            res.json({'result': 'no alerts found in payload'})            
             return
         }
 
         const roomId = utils.getRoomForReceiver(req.body.receiver)
         if (!roomId) {
-            res.json({'result': 'no rooms configured for this receiver'})
+            res.status(500)
+            res.json({'result': 'no rooms configured for this receiver'})            
             return
         }
 


### PR DESCRIPTION
Return 500 in case of 'no rooms' or 'no payload' errors.

Reason is: 200 flies with no longs on default alertmanager log level settings (INFO and above) and, at the same time, matrix-alertmanager doesn't log the failed request. 

Thanks a lot for your work :)